### PR TITLE
Added notes to package documentation 

### DIFF
--- a/R/plot_occ_temporal.R
+++ b/R/plot_occ_temporal.R
@@ -4,7 +4,7 @@
 #' @param ptheme ggplot theme
 #' @author Dominic Henry
 #' @details The function draws two plots showing occurrence record frequencies and writes them to the species directory.
-#' @note The size of the text and other elements of the plots can be change by customising the `theme` object.
+#' @note The size of the text and other elements of the plots can be change by customising the `theme` object. Also take note of the undeclared variables: `sdm_dir`, `sppselect`, `year_date`, and `undated`.
 #' @return Temporal JPEG plots: 1) `occ_frequency_date_1980_{sppselect}` and 2) `occ_frequency_date_all_{sppselect}`.
 #' @export
 #'

--- a/R/write_bart_plots.R
+++ b/R/write_bart_plots.R
@@ -5,6 +5,7 @@
 #' @param ci_theme a `rasterTheme` used for plotting the posterior width (95% credible interval) SDM map
 #' @author Dominic Henry
 #' @details The function writes 8 plots related to the species SDM predictions, both probability and binary surfaces. The species' occurrence points have been overlaid on certain plots. Plots are written to the species directory.
+#' @note There are several undeclared variables to take note of: `BART_dir`, `tss_threshold`, `occ`, `num_occ_points`, and `occurence_points`
 #' @return The following plot files:
 #' \enumerate{
 #'  \item `SDM_mean_probability.pdf`

--- a/R/write_bart_rasters.R
+++ b/R/write_bart_rasters.R
@@ -4,6 +4,7 @@
 #' @param data a `RasterStack` object returned by `embarcadero::predict2.bart()`
 #' @author Dominic Henry
 #' @details The function write outputs of both binary and probability surfaces at mean values and 95% credible intervals.
+#' @note Undeclared variables: `BART_dir`, `sppselect` and `tss_threshold`
 #' @return Seven raster layers:
 #' \enumerate{
 #'  \item `SDM_prob_mean_{sppselect}`: Mean probability of habitat suitability

--- a/man/plot_occ_temporal.Rd
+++ b/man/plot_occ_temporal.Rd
@@ -21,7 +21,7 @@ This function summarises occurrence data in a temporal context.
 The function draws two plots showing occurrence record frequencies and writes them to the species directory.
 }
 \note{
-The size of the text and other elements of the plots can be change by customising the \code{theme} object.
+The size of the text and other elements of the plots can be change by customising the \code{theme} object. Also take note of the undeclared variables: \code{sdm_dir}, \code{sppselect}, \code{year_date}, and \code{undated}.
 }
 \examples{
 \dontrun{

--- a/man/write_bart_plots.Rd
+++ b/man/write_bart_plots.Rd
@@ -33,6 +33,9 @@ This function writes plots using a combination of PDF and PNG outputs.
 \details{
 The function writes 8 plots related to the species SDM predictions, both probability and binary surfaces. The species' occurrence points have been overlaid on certain plots. Plots are written to the species directory.
 }
+\note{
+There are several undeclared variables to take note of: \code{BART_dir}, \code{tss_threshold}, \code{occ}, \code{num_occ_points}, and \code{occurence_points}
+}
 \examples{
 \dontrun{
 write_bart_plots(data = map, mean_theme = maptheme_mean, ci_theme = maptheme_ci)

--- a/man/write_bart_rasters.Rd
+++ b/man/write_bart_rasters.Rd
@@ -28,6 +28,9 @@ This function writes GeoTIFFs of BART predictions.
 \details{
 The function write outputs of both binary and probability surfaces at mean values and 95\% credible intervals.
 }
+\note{
+Undeclared variables: \code{BART_dir}, \code{sppselect} and \code{tss_threshold}
+}
 \examples{
 \dontrun{
 write_bart_rasters(map)


### PR DESCRIPTION
Included in the notes were a number of undeclared variables that are used in the functions (this should help the user know which objects not to rename).